### PR TITLE
Adding the ability to receive request params in the implementation class of the SocialUserResolveInterface

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ You must also implement `Adaojunior\Passport\SocialUserResolverInterface`:
 
 use Adaojunior\Passport\SocialGrantException;
 use Adaojunior\Passport\SocialUserResolverInterface;
+use Closure;
 
 class SocialUserResolver implements SocialUserResolverInterface
 {
@@ -44,7 +45,7 @@ class SocialUserResolver implements SocialUserResolverInterface
      * @param string $accessToken
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
-    public function resolve($network, $accessToken, $accessTokenSecret = null)
+    public function resolve($network, $accessToken, $accessTokenSecret = null, Closure $getRequestParam)
     {
         switch ($network) {
             case 'facebook':

--- a/src/SocialGrant.php
+++ b/src/SocialGrant.php
@@ -69,7 +69,8 @@ class SocialGrant extends AbstractGrant
         $user = $this->resolver->resolve(
             $this->getParameter('network', $request),
             $this->getParameter('access_token', $request),
-            $this->getParameter('access_token_secret', $request, false)
+            $this->getParameter('access_token_secret', $request, false),
+            $this->getParam($request)
         );
 
         if($user instanceof Authenticatable)
@@ -83,6 +84,18 @@ class SocialGrant extends AbstractGrant
         }
 
         return $user;
+    }
+    
+    /**
+     * @param ServerRequestInterface $request
+     * @return Closure
+     */
+    protected function getParam(ServerRequestInterface $request)
+    {
+           return function($param) use ($request)
+           {
+               return $this->getParameter($param, $request);
+           }
     }
 
     protected function getParameter($param, ServerRequestInterface $request, $required = true)

--- a/src/SocialGrant.php
+++ b/src/SocialGrant.php
@@ -94,7 +94,7 @@ class SocialGrant extends AbstractGrant
     {
            return function($param) use ($request)
            {
-               return $this->getParameter($param, $request);
+               return $this->getRequestParameter($param, $request);
            }
     }
 

--- a/src/SocialGrant.php
+++ b/src/SocialGrant.php
@@ -95,7 +95,7 @@ class SocialGrant extends AbstractGrant
            return function($param) use ($request)
            {
                return $this->getRequestParameter($param, $request);
-           }
+           };
     }
 
     protected function getParameter($param, ServerRequestInterface $request, $required = true)

--- a/src/SocialUserResolverInterface.php
+++ b/src/SocialUserResolverInterface.php
@@ -2,6 +2,7 @@
 
 namespace Adaojunior\Passport;
 
+use Closure;
 
 interface SocialUserResolverInterface
 {
@@ -11,7 +12,8 @@ interface SocialUserResolverInterface
      * @param string $network
      * @param string $accessToken
      * @param string|null $accessTokenSecret
+     * @param Closure $getRequestParam
      * @return mixed
      */
-    public function resolve($network, $accessToken, $accessTokenSecret = null);
+    public function resolve($network, $accessToken, $accessTokenSecret = null, Closure $getRequestParam);
 }

--- a/src/SocialUserResolverInterface.php
+++ b/src/SocialUserResolverInterface.php
@@ -15,5 +15,5 @@ interface SocialUserResolverInterface
      * @param Closure $getRequestParam
      * @return mixed
      */
-    public function resolve($network, $accessToken, $accessTokenSecret = null, Closure $getRequestParam);
+    public function resolve($network, $accessToken, $accessTokenSecret = null, Closure $getParam);
 }


### PR DESCRIPTION
If we need to fetch request param from the implementation class of the SocialUserResolverInterface. we can use the closure to get the request params