### PR TITLE
Update laravel/passport version requirement 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "laravel/passport": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
+        "laravel/passport": "^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "laravel/passport": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "laravel/passport": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,11 @@ $this->app->bind(
 );
 ```
 
+3. Finally, add the grant `social` to the `grant_types` array attribute for all `clients` that need it in the `oauth_clients` table.
+
+> [!WARNING]
+> If you started using Passport before version 13.x, make sure to update the `oauth_clients` table using the migration described here: https://github.com/laravel/passport/blob/13.x/UPGRADE.md#oauth-client-table-changes-optional
+
 ## Usage
 
 

--- a/src/SocialGrant.php
+++ b/src/SocialGrant.php
@@ -32,7 +32,7 @@ class SocialGrant extends AbstractGrant
         self::$providerParamName = $value ? 'network' : 'provider';
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return 'social';
     }
@@ -49,7 +49,7 @@ class SocialGrant extends AbstractGrant
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
         DateInterval $accessTokenTTL
-    ) {
+    ): ResponseTypeInterface {
 
         // Validate request
         $client = $this->validateClient($request);
@@ -83,7 +83,7 @@ class SocialGrant extends AbstractGrant
      * @return UserEntityInterface
      * @throws OAuthServerException
      */
-    protected function validateUser(ServerRequestInterface $request, ClientEntityInterface $client)
+    protected function validateUser(ServerRequestInterface $request, ClientEntityInterface $client): UserEntityInterface
     {
         $user = $this->provider->getUserByAccessToken(
             $this->getParameter(self::$providerParamName, $request),


### PR DESCRIPTION
### ⚠️ Breaking Change

This PR introduces **typed interfaces**, which required dropping compatibility with Laravel Passport versions below **v13**.

Since I’ve been maintaining this package since 2020, I’d also suggest that users consider migrating to https://github.com/coderello/laravel-passport-social-grant, a similar package that I actively maintain, for continued updates and support.

Since I’ve been maintaining this package since 2020, I suggest archiving this repository and encouraging users to migrate to https://github.com/coderello/laravel-passport-social-grant, a similar package that is actively maintained by its author, for continued updates and support.